### PR TITLE
Modify source of dark mode information

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import { ToastContainer, toast } from 'react-toastify';
 
 // Custom components
 import MyDutiesCard from './MyDuties';
-import WeeklyView from './WeeklyView'
+import WeeklyView from './WeeklyView';
 import Stats from './Stats';
 import catchResponseError from './responseError';
 
@@ -19,7 +19,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 // Animations
 import shrugAnimationData from "./animations/shrug.json";
-import deniedAnimationData from "./animations/denied.json"
+import deniedAnimationData from "./animations/denied.json";
 
 const departments = {'lns': 'ЛНС', 'gp': 'ГП', 'di': 'ДИ'};
 const apiUrl = process.env.REACT_APP_PROXY_URL;
@@ -403,6 +403,7 @@ function UserEditForm({ branch, editingUser, setEditingUser, initDataUnsafe }){
 
 function App() {
   const [initDataUnsafe, setInitDataUnsafe] = useState(null);
+  const [theme, setTheme] = useState('light')
   const [rotaData, setRotaData] = useState({});
   const [rotaAdmin, setRotaAdmin] = useState([]);
   const [date, setDate] = useState(today);
@@ -444,15 +445,16 @@ function App() {
       console.warn('Telegram WebApp is not avaliable')
       return
     } else if (Object.keys(window.Telegram.WebApp.initDataUnsafe).length === 0) {
-      console.log('Using mock Telegram data')
-      console.log(process.env.REACT_APP_INIT_DATA_UNSAFE)
-        setInitDataUnsafe(JSON.parse(process.env.REACT_APP_INIT_DATA_UNSAFE))
+      console.log('Using mock Telegram data');
+      console.log(process.env.REACT_APP_INIT_DATA_UNSAFE);
+      setTheme('light');
+      setInitDataUnsafe(JSON.parse(process.env.REACT_APP_INIT_DATA_UNSAFE));
     } else {
       console.log('Using real Telegram data');
+      setTheme(window.Telegram.WebApp.colorScheme);
       setInitDataUnsafe(window.Telegram.WebApp.initDataUnsafe);
       window.Telegram.WebApp.disableVerticalSwipes();
       window.Telegram.WebApp.expand();
-
       storeLastLogin();
     }
   }, []);
@@ -609,7 +611,7 @@ function App() {
 
 
   return (
-    <div className="app">
+    <div className={`app ${theme}`}>
       <h1 className='text-3xl font-bold mb-2 dark:text-slate-100'>График</h1>
 
       {isLoading && (

--- a/src/App.js
+++ b/src/App.js
@@ -403,7 +403,7 @@ function UserEditForm({ branch, editingUser, setEditingUser, initDataUnsafe }){
 
 function App() {
   const [initDataUnsafe, setInitDataUnsafe] = useState(null);
-  const [theme, setTheme] = useState('light')
+  const [theme, setTheme] = useState('light');
   const [rotaData, setRotaData] = useState({});
   const [rotaAdmin, setRotaAdmin] = useState([]);
   const [date, setDate] = useState(today);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'selector',
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
   ],


### PR DESCRIPTION
Instead of relying on browser information for theme settings make use of Telegram's `colourScheme`. 

This change uses `useState` functionality to get the theme from the corresponding Telegram object. Tailwind CSS adapts its dark state based on the `class = dark` of the `app` div

Closes #44